### PR TITLE
Fix WSS: login2fa() does not trigger wss connect

### DIFF
--- a/vrcpy/wss.py
+++ b/vrcpy/wss.py
@@ -356,6 +356,8 @@ class AWSSClient(AClient, _WSSClient):
 
     async def login2fa(self, username, password, code=None, verify=False):
         await super().login2fa(username, password, code, verify)
+        if self.loggedIn:
+            self.connect()
 
     async def verify2fa(self, code):
         await super().verify2fa(code)


### PR DESCRIPTION
While login() triggers self.connect() if login is successful, login2fa() does not, causing the client to just idle.
Fix by adding self.connect() trigger to login2fa().