### PR TITLE
Missing pluginUrl fix

### DIFF
--- a/vrcpy/objects.py
+++ b/vrcpy/objects.py
@@ -467,7 +467,6 @@ class World(LimitedWorld):
 
         self.unique += [
             "namespace",
-            "pluginUrl",
             "previewYoutubeId",
             "instances"
         ]


### PR DESCRIPTION
VRChat API stopped returning a `pluginUrl` field from `/worlds/[id]` calls, so creating and filling the World object throws an exception:
`vrcpy.errors.IntegretyError: Object does not have unique key (pluginUrl) for World (Class definition may be outdated, please make an issue on github)`
